### PR TITLE
refactored out ObjectMapper

### DIFF
--- a/src/main/java/io/progix/dropwizard/patch/BasicJsonPatch.java
+++ b/src/main/java/io/progix/dropwizard/patch/BasicJsonPatch.java
@@ -43,7 +43,6 @@ import java.util.Set;
  * {@link BasicJsonPatch#apply()} is used to apply all handler logic and should be called before the end of the resource
  * method for patching to occur.
  */
-@JsonDeserialize(using = BasicJsonPatchDeserializer.class)
 public class BasicJsonPatch {
 
     private List<JsonPatchOperation> operations;

--- a/src/main/java/io/progix/dropwizard/patch/BasicJsonPatchDeserializer.java
+++ b/src/main/java/io/progix/dropwizard/patch/BasicJsonPatchDeserializer.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.dropwizard.jackson.Jackson;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.progix.jackson.JsonPatchOperation;
 
 import java.io.IOException;
@@ -34,11 +34,22 @@ import java.util.Arrays;
  */
 public class BasicJsonPatchDeserializer extends JsonDeserializer<BasicJsonPatch> {
 
+    private final ObjectMapper mapper;
+
+    public BasicJsonPatchDeserializer(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
     @Override
     public BasicJsonPatch deserialize(JsonParser jp,
                                  DeserializationContext ctxt) throws IOException, JsonProcessingException {
-        ObjectMapper mapper = Jackson.newObjectMapper();
         JsonPatchOperation[] instructions = mapper.readValue(jp, JsonPatchOperation[].class);
         return new BasicJsonPatch(Arrays.asList(instructions));
+    }
+
+    public void register() {
+        final SimpleModule module = new SimpleModule();
+        module.addDeserializer(BasicJsonPatch.class, this);
+        mapper.registerModule(module);
     }
 }

--- a/src/main/java/io/progix/dropwizard/patch/ContextualJsonPatch.java
+++ b/src/main/java/io/progix/dropwizard/patch/ContextualJsonPatch.java
@@ -17,6 +17,7 @@
 package io.progix.dropwizard.patch;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.progix.dropwizard.patch.exception.PatchOperationNotSupportedException;
 import io.progix.dropwizard.patch.operations.contextual.ContextualAddOperation;
@@ -47,10 +48,12 @@ import java.util.Set;
  *
  * @param <T> The type of object that will be patched
  */
-@JsonDeserialize(using = ContextualJsonPatchDeserializer.class)
 public class ContextualJsonPatch<T> {
 
     protected List<JsonPatchOperation> operations;
+
+    @JsonIgnore
+    protected final ObjectMapper mapper;
 
     @JsonIgnore
     protected ContextualAddOperation<T> addOperation;
@@ -70,8 +73,9 @@ public class ContextualJsonPatch<T> {
      *
      * @param operations A list of {@link JsonPatchOperation}
      */
-    public ContextualJsonPatch(List<JsonPatchOperation> operations) {
+    public ContextualJsonPatch(List<JsonPatchOperation> operations, ObjectMapper mapper) {
         this.operations = operations;
+        this.mapper = mapper;
     }
 
     /**
@@ -98,7 +102,7 @@ public class ContextualJsonPatch<T> {
      */
     public T apply(T context) throws JsonPatchTestFailedException {
 
-        T copiedContext = PatchUtil.copy(context);
+        T copiedContext = PatchUtil.copy(context, mapper);
 
         Set<JsonPatchOperationType> unsupportedOperationTypes = new HashSet<>();
 

--- a/src/main/java/io/progix/dropwizard/patch/ContextualJsonPatchDeserializer.java
+++ b/src/main/java/io/progix/dropwizard/patch/ContextualJsonPatchDeserializer.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.dropwizard.jackson.Jackson;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.progix.jackson.JsonPatchOperation;
 
 import java.io.IOException;
@@ -35,11 +35,22 @@ import java.util.Arrays;
  */
 public class ContextualJsonPatchDeserializer extends JsonDeserializer<ContextualJsonPatch<?>> {
 
+    private final ObjectMapper mapper;
+
+    public ContextualJsonPatchDeserializer(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
     @Override
     public ContextualJsonPatch<?> deserialize(JsonParser jp,
                                               DeserializationContext ctxt) throws IOException, JsonProcessingException {
-        ObjectMapper mapper = Jackson.newObjectMapper();
         JsonPatchOperation[] instructions = mapper.readValue(jp, JsonPatchOperation[].class);
-        return new ContextualJsonPatch<Object>(Arrays.asList(instructions));
+        return new ContextualJsonPatch<Object>(Arrays.asList(instructions), mapper);
+    }
+
+    public void register() {
+        final SimpleModule module = new SimpleModule();
+        module.addDeserializer(ContextualJsonPatch.class, this);
+        mapper.registerModule(module);
     }
 }

--- a/src/main/java/io/progix/dropwizard/patch/DefaultJsonPatch.java
+++ b/src/main/java/io/progix/dropwizard/patch/DefaultJsonPatch.java
@@ -19,36 +19,28 @@ package io.progix.dropwizard.patch;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import io.dropwizard.jackson.Jackson;
 import io.progix.jackson.JsonPatchOperation;
 import io.progix.jackson.exceptions.JsonPatchTestFailedException;
 
 import java.util.List;
 
-
-@JsonDeserialize(using = DefaultJsonPatchDeserializer.class)
 public class DefaultJsonPatch<T> extends ContextualJsonPatch<T> {
-
-    @JsonIgnore
-    private final ObjectMapper mapper;
 
     /**
      * Constructs an instance using a list of {@link JsonPatchOperation}
      *
      * @param operations A list of {@link JsonPatchOperation}
+     * @param mapper
      */
-    public DefaultJsonPatch(List<JsonPatchOperation> operations) {
-        super(operations);
-
-        this.mapper = Jackson.newObjectMapper();
+    public DefaultJsonPatch(List<JsonPatchOperation> operations, ObjectMapper mapper) {
+        super(operations, mapper);
     }
 
     @Override
     public T apply(T context) throws JsonPatchTestFailedException {
         Class<T> typeClass = (Class<T>) context.getClass();
 
-        T copiedContext = PatchUtil.copy(context);
+        T copiedContext = PatchUtil.copy(context, mapper);
 
         for (JsonPatchOperation instruction : operations) {
 

--- a/src/main/java/io/progix/dropwizard/patch/DefaultJsonPatchDeserializer.java
+++ b/src/main/java/io/progix/dropwizard/patch/DefaultJsonPatchDeserializer.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.dropwizard.jackson.Jackson;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.progix.jackson.JsonPatchOperation;
 
 import java.io.IOException;
@@ -36,11 +36,22 @@ import java.util.Arrays;
  */
 public class DefaultJsonPatchDeserializer extends JsonDeserializer<DefaultJsonPatch<?>> {
 
+	private final ObjectMapper mapper;
+
+	public DefaultJsonPatchDeserializer(ObjectMapper mapper) {
+		this.mapper = mapper;
+	}
+
 	@Override
 	public DefaultJsonPatch<?> deserialize(JsonParser jp,
 			DeserializationContext ctxt) throws IOException, JsonProcessingException {
-		ObjectMapper mapper = Jackson.newObjectMapper();
 		JsonPatchOperation[] instructions = mapper.readValue(jp, JsonPatchOperation[].class);
-		return new DefaultJsonPatch<Object>(Arrays.asList(instructions));
+		return new DefaultJsonPatch<Object>(Arrays.asList(instructions), mapper);
+	}
+
+	public void register() {
+		final SimpleModule module = new SimpleModule();
+		module.addDeserializer(DefaultJsonPatch.class, this);
+		mapper.registerModule(module);
 	}
 }

--- a/src/main/java/io/progix/dropwizard/patch/JsonPatchDeserializerHelper.java
+++ b/src/main/java/io/progix/dropwizard/patch/JsonPatchDeserializerHelper.java
@@ -1,0 +1,14 @@
+package io.progix.dropwizard.patch;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Created by dsmith on 3/1/16.
+ */
+public class JsonPatchDeserializerHelper {
+    public static void register(ObjectMapper mapper) {
+        new ContextualJsonPatchDeserializer(mapper).register();
+        new BasicJsonPatchDeserializer(mapper).register();
+        new DefaultJsonPatchDeserializer(mapper).register();
+    }
+}

--- a/src/main/java/io/progix/dropwizard/patch/JsonPatchValue.java
+++ b/src/main/java/io/progix/dropwizard/patch/JsonPatchValue.java
@@ -17,7 +17,7 @@
 package io.progix.dropwizard.patch;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.dropwizard.jackson.Jackson;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,21 +44,22 @@ public class JsonPatchValue {
      * This method is used to cast and map the list of objects in this class to a specified known class using Jackson
      *
      * @param clazz The class to cast the elements of this list to
+     * @param mapper
      * @param <T>   The class type of the class param
      *
      * @return A list of value casted and mapped to the specified class
      */
-    public <T> List<T> many(Class<T> clazz) {
+    public <T> List<T> many(Class<T> clazz, ObjectMapper mapper) {
         List<T> mappedValues = new ArrayList<>();
         if (value.isArray()) {
             for (JsonNode valueElement : value) {
                 if (valueElement == null) {
                     mappedValues.add(null);
                 }
-                mappedValues.add(Jackson.newObjectMapper().convertValue(valueElement, clazz));
+                mappedValues.add(mapper.convertValue(valueElement, clazz));
             }
         } else {
-            mappedValues.add(Jackson.newObjectMapper().convertValue(value, clazz));
+            mappedValues.add(mapper.convertValue(value, clazz));
         }
         return mappedValues;
     }
@@ -67,17 +68,18 @@ public class JsonPatchValue {
      * This method is used to cast and map the list of objects in this class to a specified known class using Jackson
      *
      * @param clazz The class to cast the single element of this list to
+     * @param mapper
      * @param <T>   The class type of the class param
      *
      * @return A single value casted and mapped to the specified class.
      *
      * @throws IndexOutOfBoundsException if there is more than one element in the list or if the list is empty.
      */
-    public <T> T one(Class<T> clazz) {
+    public <T> T one(Class<T> clazz, ObjectMapper mapper) {
         if (value.isArray()) {
             throw new UnsupportedOperationException("Cannot convert a list of values into one. See many(Class");
         }
-        return Jackson.newObjectMapper().convertValue(value, clazz);
+        return mapper.convertValue(value, clazz);
     }
 
     public JsonNode getNode() {

--- a/src/main/java/io/progix/dropwizard/patch/PatchUtil.java
+++ b/src/main/java/io/progix/dropwizard/patch/PatchUtil.java
@@ -8,9 +8,7 @@ import java.io.IOException;
 
 public class PatchUtil {
 
-    public static final ObjectMapper mapper = Jackson.newObjectMapper();
-
-    public static <T> T copy(T object) {
+    public static <T> T copy(T object, ObjectMapper mapper) {
         if(object instanceof JsonNode) {
             return (T) ((JsonNode) object).deepCopy();
         }

--- a/src/test/java/io/progix/dropwizard/patch/UserResource.java
+++ b/src/test/java/io/progix/dropwizard/patch/UserResource.java
@@ -82,26 +82,26 @@ public class UserResource {
 						if (path.element(1).exists() && path.endsAt(1)) {
 							if (!path.property(2).exists()) {
 								if(path.element(1).isEndOfArray()) {
-									user.getPets().addAll(value.many(Pet.class));
+									user.getPets().addAll(value.many(Pet.class, mapper));
 								} else {
 									int petIndex = path.element(1).val();
-									user.getPets().addAll(petIndex, value.many(Pet.class));
+									user.getPets().addAll(petIndex, value.many(Pet.class, mapper));
 								}
 							} else {
 								throw new InvalidPatchPathException(path);
 							}
 						} else if (path.endsAt(0)) {
-							user.getPets().addAll(value.many(Pet.class));
+							user.getPets().addAll(value.many(Pet.class, mapper));
 						} else {
 							throw new InvalidPatchPathException(path);
 						}
 					} else if (path.property(0).is("name")) {
-						user.setName(value.one(String.class));
+						user.setName(value.one(String.class, mapper));
 					} else if (path.property(0).is("emailAddresses")) {
 						if (path.element(1).exists() && path.endsAt(1)) {
-							user.getEmailAddresses().addAll(path.element(1).val(), value.many(String.class));
+							user.getEmailAddresses().addAll(path.element(1).val(), value.many(String.class, mapper));
 						} else if (path.endsAt(0)) {
-							user.getEmailAddresses().addAll(value.many(String.class));
+							user.getEmailAddresses().addAll(value.many(String.class, mapper));
 						} else {
 							throw new InvalidPatchPathException(path);
 						}
@@ -144,26 +144,26 @@ public class UserResource {
                         if (path.element(1).exists() && path.endsAt(1)) {
                             if (!path.property(2).exists()) {
                                 if(path.element(1).isEndOfArray()) {
-                                    user.getPets().addAll(value.many(Pet.class));
+                                    user.getPets().addAll(value.many(Pet.class, mapper));
                                 } else {
                                     int petIndex = path.element(1).val();
-                                    user.getPets().addAll(petIndex, value.many(Pet.class));
+                                    user.getPets().addAll(petIndex, value.many(Pet.class, mapper));
                                 }
                             } else {
                                 throw new InvalidPatchPathException(path);
                             }
                         } else if (path.endsAt(0)) {
-                            user.getPets().addAll(value.many(Pet.class));
+                            user.getPets().addAll(value.many(Pet.class, mapper));
                         } else {
                             throw new InvalidPatchPathException(path);
                         }
                     } else if (path.property(0).is("name")) {
-                        user.setName(value.one(String.class));
+                        user.setName(value.one(String.class, mapper));
                     } else if (path.property(0).is("emailAddresses")) {
                         if (path.element(1).exists() && path.endsAt(1)) {
-                            user.getEmailAddresses().addAll(path.element(1).val(), value.many(String.class));
+                            user.getEmailAddresses().addAll(path.element(1).val(), value.many(String.class, mapper));
                         } else if (path.endsAt(0)) {
-                            user.getEmailAddresses().addAll(value.many(String.class));
+                            user.getEmailAddresses().addAll(value.many(String.class, mapper));
                         } else {
                             throw new InvalidPatchPathException(path);
                         }
@@ -264,19 +264,19 @@ public class UserResource {
                     if (path.property(0).is("pets")) {
                         if (path.element(1).exists() && path.endsAt(1)) {
                             int petIndex = path.element(1).val();
-                            user.getPets().set(petIndex, value.one(Pet.class));
+                            user.getPets().set(petIndex, value.one(Pet.class, mapper));
                         } else if (path.endsAt(0)) {
-                            user.setPets(value.many(Pet.class));
+                            user.setPets(value.many(Pet.class, mapper));
                         } else {
                             throw new InvalidPatchPathException(path);
                         }
                     } else if (path.property(0).is("name") && path.endsAt(0)) {
-                        user.setName(value.one(String.class));
+                        user.setName(value.one(String.class, mapper));
                     } else if (path.property(0).is("emailAddresses")) {
                         if (path.element(1).exists() && path.endsAt(1)) {
-                            user.getEmailAddresses().set(path.element(1).val(), value.one(String.class));
+                            user.getEmailAddresses().set(path.element(1).val(), value.one(String.class, mapper));
                         } else if (path.endsAt(0)) {
-                            user.setEmailAddresses(value.many(String.class));
+                            user.setEmailAddresses(value.many(String.class, mapper));
                         } else {
                             throw new InvalidPatchPathException(path);
                         }
@@ -298,18 +298,18 @@ public class UserResource {
                     if (path.property(0).is("pets")) {
                         if (path.element(1).exists() && path.endsAt(1)) {
                             int petIndex = path.element(1).val();
-                            return Objects.equals(user.getPets().get(petIndex), value.one(Pet.class));
+                            return Objects.equals(user.getPets().get(petIndex), value.one(Pet.class, mapper));
                         } else if (path.endsAt(0)) {
-                            return Objects.equals(user.getPets(), value.many(Pet.class));
+                            return Objects.equals(user.getPets(), value.many(Pet.class, mapper));
                         }
                     } else if (path.property(0).is("name") && path.endsAt(0)) {
-                        return Objects.equals(user.getName(), value.one(String.class));
+                        return Objects.equals(user.getName(), value.one(String.class, mapper));
                     } else if (path.property(0).is("emailAddresses")) {
                         if (path.element(1).exists() && path.endsAt(1)) {
                             return Objects.equals(user.getEmailAddresses().get(path.element(1).val()),
-                                    value.one(String.class));
+                                    value.one(String.class, mapper));
                         } else if (path.endsAt(0)) {
-                            return Objects.equals(user.getEmailAddresses(), value.many(String.class));
+                            return Objects.equals(user.getEmailAddresses(), value.many(String.class, mapper));
                         }
                     }
                 }
@@ -343,26 +343,26 @@ public class UserResource {
                         if (path.element(1).exists() && path.endsAt(1)) {
                             if (!path.property(2).exists()) {
 								if(path.element(1).isEndOfArray()) {
-									user.getPets().addAll(value.many(Pet.class));
+									user.getPets().addAll(value.many(Pet.class, mapper));
 								} else {
 									int petIndex = path.element(1).val();
-									user.getPets().addAll(petIndex, value.many(Pet.class));
+									user.getPets().addAll(petIndex, value.many(Pet.class, mapper));
 								}
                             } else {
                                 throw new InvalidPatchPathException(path);
                             }
                         } else if (path.endsAt(0)) {
-                            user.getPets().addAll(value.many(Pet.class));
+                            user.getPets().addAll(value.many(Pet.class, mapper));
                         } else {
                             throw new InvalidPatchPathException(path);
                         }
                     } else if (path.property(0).is("name")) {
-                        user.setName(value.one(String.class));
+                        user.setName(value.one(String.class, mapper));
                     } else if (path.property(0).is("emailAddresses")) {
                         if (path.element(1).exists() && path.endsAt(1)) {
-                            user.getEmailAddresses().addAll(path.element(1).val(), value.many(String.class));
+                            user.getEmailAddresses().addAll(path.element(1).val(), value.many(String.class, mapper));
                         } else if (path.endsAt(0)) {
-                            user.getEmailAddresses().addAll(value.many(String.class));
+                            user.getEmailAddresses().addAll(value.many(String.class, mapper));
                         } else {
                             throw new InvalidPatchPathException(path);
                         }
@@ -449,19 +449,19 @@ public class UserResource {
                     if (path.property(0).is("pets")) {
                         if (path.element(1).exists() && path.endsAt(1)) {
                             int petIndex = path.element(1).val();
-                            user.getPets().set(petIndex, value.one(Pet.class));
+                            user.getPets().set(petIndex, value.one(Pet.class, mapper));
                         } else if (path.endsAt(0)) {
-                            user.setPets(value.many(Pet.class));
+                            user.setPets(value.many(Pet.class, mapper));
                         } else {
                             throw new InvalidPatchPathException(path);
                         }
                     } else if (path.property(0).is("name") && path.endsAt(0)) {
-                        user.setName(value.one(String.class));
+                        user.setName(value.one(String.class, mapper));
                     } else if (path.property(0).is("emailAddresses")) {
                         if (path.element(1).exists() && path.endsAt(1)) {
-                            user.getEmailAddresses().set(path.element(1).val(), value.one(String.class));
+                            user.getEmailAddresses().set(path.element(1).val(), value.one(String.class, mapper));
                         } else if (path.endsAt(0)) {
-                            user.setEmailAddresses(value.many(String.class));
+                            user.setEmailAddresses(value.many(String.class, mapper));
                         } else {
                             throw new InvalidPatchPathException(path);
                         }
@@ -481,18 +481,18 @@ public class UserResource {
                     if (path.property(0).is("pets")) {
                         if (path.element(1).exists() && path.endsAt(1)) {
                             int petIndex = path.element(1).val();
-                            return Objects.equals(user.getPets().get(petIndex), value.one(Pet.class));
+                            return Objects.equals(user.getPets().get(petIndex), value.one(Pet.class, mapper));
                         } else if (path.endsAt(0)) {
-                            return Objects.equals(user.getPets(), value.many(Pet.class));
+                            return Objects.equals(user.getPets(), value.many(Pet.class, mapper));
                         }
                     } else if (path.property(0).is("name") && path.endsAt(0)) {
-                        return Objects.equals(user.getName(), value.one(String.class));
+                        return Objects.equals(user.getName(), value.one(String.class, mapper));
                     } else if (path.property(0).is("emailAddresses")) {
                         if (path.element(1).exists() && path.endsAt(1)) {
                             return Objects.equals(user.getEmailAddresses().get(path.element(1).val()),
-                                    value.one(String.class));
+                                    value.one(String.class, mapper));
                         } else if (path.endsAt(0)) {
-                            return Objects.equals(user.getEmailAddresses(), value.many(String.class));
+                            return Objects.equals(user.getEmailAddresses(), value.many(String.class, mapper));
                         }
                     }
                 }

--- a/src/test/java/io/progix/dropwizard/patch/test/BasicJsonPatchOperationTest.java
+++ b/src/test/java/io/progix/dropwizard/patch/test/BasicJsonPatchOperationTest.java
@@ -22,6 +22,9 @@ import static org.junit.Assert.fail;
 public class BasicJsonPatchOperationTest {
 
     private static final ObjectMapper MAPPER = Jackson.newObjectMapper();
+    static {
+        JsonPatchDeserializerHelper.register(MAPPER);
+    }
 
     private final Map<JsonPatchOperationType, Boolean> includeMap;
 

--- a/src/test/java/io/progix/dropwizard/patch/test/DefaultJsonPatchTest.java
+++ b/src/test/java/io/progix/dropwizard/patch/test/DefaultJsonPatchTest.java
@@ -4,7 +4,11 @@ import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
+import io.progix.dropwizard.patch.BasicJsonPatchDeserializer;
+import io.progix.dropwizard.patch.ContextualJsonPatchDeserializer;
 import io.progix.dropwizard.patch.DefaultJsonPatch;
+import io.progix.dropwizard.patch.DefaultJsonPatchDeserializer;
+import io.progix.dropwizard.patch.JsonPatchDeserializerHelper;
 import io.progix.jackson.JsonPatchOperation;
 import io.progix.jackson.JsonPatchOperationType;
 import org.junit.Before;
@@ -19,10 +23,12 @@ public class DefaultJsonPatchTest {
     @Before
     public void init() {
         ObjectMapper mapper = Jackson.newObjectMapper();
+        JsonPatchDeserializerHelper.register(mapper);
+
         JsonPatchOperation add = new JsonPatchOperation(JsonPatchOperationType.ADD,
                 JsonPointer.compile("/"), mapper.convertValue("test", JsonNode.class));
 
-        patch = new DefaultJsonPatch<>(Arrays.asList(add));
+        patch = new DefaultJsonPatch<>(Arrays.asList(add), mapper);
     }
 
     @Test

--- a/src/test/java/io/progix/dropwizard/patch/test/ExceptionMapperResourceTest.java
+++ b/src/test/java/io/progix/dropwizard/patch/test/ExceptionMapperResourceTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.testing.junit.ResourceTestRule;
+import io.progix.dropwizard.patch.JsonPatchDeserializerHelper;
 import io.progix.dropwizard.patch.Pet;
 import io.progix.dropwizard.patch.UserResource;
 import io.progix.dropwizard.patch.UserStore;
@@ -28,14 +29,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ExceptionMapperResourceTest {
 
-    private ObjectMapper mapper = Jackson.newObjectMapper();
+    private static ObjectMapper mapper = Jackson.newObjectMapper();
+    static {
+        JsonPatchDeserializerHelper.register(mapper);
+    }
+
     private UserStore dao = new UserStore();
 
     @Rule
-    public ResourceTestRule resources = ResourceTestRule.builder().addProvider(PatchTestFailedExceptionMapper.class)
+    public ResourceTestRule resources = ResourceTestRule.builder()
+            .setMapper(mapper)
+            .addProvider(PatchTestFailedExceptionMapper.class)
             .addProvider(PatchOperationNotSupportedExceptionMapper.class)
-            .addProvider(InvalidPatchPathExceptionMapper.class).
-                    addResource(new UserResource(dao)).build();
+            .addProvider(InvalidPatchPathExceptionMapper.class)
+            .addResource(new UserResource(dao))
+            .build();
 
     @Test
     public void testContextualInvalidPath() {

--- a/src/test/java/io/progix/dropwizard/patch/test/JsonPatchResourceTest.java
+++ b/src/test/java/io/progix/dropwizard/patch/test/JsonPatchResourceTest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.testing.junit.ResourceTestRule;
+import io.progix.dropwizard.patch.JsonPatchDeserializerHelper;
 import io.progix.dropwizard.patch.Pet;
 import io.progix.dropwizard.patch.User;
 import io.progix.dropwizard.patch.UserResource;
@@ -47,11 +48,17 @@ public class JsonPatchResourceTest {
     private String type;
     private UserStore dao = new UserStore();
 
-    private ObjectMapper mapper = Jackson.newObjectMapper();
+    private static ObjectMapper mapper = Jackson.newObjectMapper();
+    static {
+        JsonPatchDeserializerHelper.register(mapper);
+    }
 
     @Rule
-    public ResourceTestRule resources = ResourceTestRule.builder().addProvider(PatchTestFailedExceptionMapper.class).
-            addResource(new UserResource(dao)).build();
+    public ResourceTestRule resources = ResourceTestRule.builder()
+            .setMapper(mapper)
+            .addProvider(PatchTestFailedExceptionMapper.class)
+            .addResource(new UserResource(dao))
+            .build();
 
     public JsonPatchResourceTest(String type) {
         this.type = type;

--- a/src/test/java/io/progix/dropwizard/patch/test/JsonPatchSerializationTest.java
+++ b/src/test/java/io/progix/dropwizard/patch/test/JsonPatchSerializationTest.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
 import io.progix.dropwizard.patch.ContextualJsonPatch;
 import io.progix.dropwizard.patch.BasicJsonPatch;
+import io.progix.dropwizard.patch.JsonPatchDeserializerHelper;
 import io.progix.jackson.JsonPatchOperation;
 import io.progix.jackson.JsonPatchOperationType;
 import org.junit.Before;
@@ -35,6 +36,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JsonPatchSerializationTest {
 
     private static final ObjectMapper mapper = Jackson.newObjectMapper();
+    static {
+        JsonPatchDeserializerHelper.register(mapper);
+    }
 
     private JsonPatchOperation rp1, rp2, rp3, rp4, rp5, rp6, rp7, rp8, rp9, rp10, rp11, rp12, a1, a2, a3, a4, a5, a6, a7,
             a8, a9, a10, a11, a12, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, m1, m2, m3, m4, m5,
@@ -134,7 +138,7 @@ public class JsonPatchSerializationTest {
         ContextualJsonPatch<?> contextualRequest = new ContextualJsonPatch<Object>(
                 Arrays.asList(rp1, rp2, rp3, rp4, rp5, rp6, rp7, rp8, rp9, rp10, rp11, rp12, a1, a2, a3, a4, a5, a6, a7,
                         a8, a9, a10, a11, a12, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, m1, m2, m3, m4, m5,
-                        m6, m7, m8, m9, c1, c2, c3, c4, c5, c6, c7, c8, c9, rm1, rm2, rm3));
+                        m6, m7, m8, m9, c1, c2, c3, c4, c5, c6, c7, c8, c9, rm1, rm2, rm3), mapper);
         assertThat(mapper.readValue(fixture("fixtures/patchrequest.json"), ContextualJsonPatch.class)).isEqualTo(
                 contextualRequest);
     }

--- a/src/test/java/io/progix/dropwizard/patch/test/SpecTests.java
+++ b/src/test/java/io/progix/dropwizard/patch/test/SpecTests.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.testing.FixtureHelpers;
 import io.progix.dropwizard.patch.DefaultJsonPatch;
+import io.progix.dropwizard.patch.JsonPatchDeserializerHelper;
 import io.progix.dropwizard.patch.JsonTestCase;
 import io.progix.jackson.JsonPatchOperation;
 import io.progix.jackson.exceptions.JsonPatchFailedException;
@@ -40,7 +41,10 @@ import static org.assertj.core.api.Assertions.fail;
 public class SpecTests {
 
     private final JsonTestCase testCase;
-    private final ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper mapper = new ObjectMapper();
+    static {
+        JsonPatchDeserializerHelper.register(mapper);
+    }
 
     public SpecTests(JsonTestCase testCase) {
         this.testCase = testCase;
@@ -56,7 +60,7 @@ public class SpecTests {
             JsonNode documentNode = mapper.readTree(testCase.getDoc());
 
             JsonPatchOperation[] patchOperations = mapper.convertValue(testCase.getPatch(), JsonPatchOperation[].class);
-            DefaultJsonPatch<JsonNode>  patch = new DefaultJsonPatch<>(Arrays.asList(patchOperations));
+            DefaultJsonPatch<JsonNode>  patch = new DefaultJsonPatch<>(Arrays.asList(patchOperations), mapper);
 
             JsonNode resultNode = patch.apply(documentNode);
             if (testCase.isErrorCase()) {
@@ -81,7 +85,6 @@ public class SpecTests {
     public static Collection<Object[]> data() {
         List<Object[]> datas = new ArrayList<Object[]>();
 
-        ObjectMapper mapper = new ObjectMapper();
         JsonTestCase[] testCases;
 
         try {


### PR DESCRIPTION
Refactored out ObjectMapper instantiations. Saves a lot on object generation (ObjectMapper instantiation is expensive). Allows dropwizard-patch to be used with objects that require custom deserialization.
